### PR TITLE
RocksDBStore - delete()

### DIFF
--- a/versioned/tiered/mongodb/src/test/java/com/dremio/nessie/versioned/store/mongodb/TestMongoDBStore.java
+++ b/versioned/tiered/mongodb/src/test/java/com/dremio/nessie/versioned/store/mongodb/TestMongoDBStore.java
@@ -107,6 +107,26 @@ class TestMongoDBStore extends AbstractTestStore<MongoDBStore> {
 
   @Test
   @Disabled
+  void deleteConditionMismatchAttributeValue() {
+  }
+
+  @Test
+  @Disabled
+  void deleteConditionMismatchAttributeBranch() {
+  }
+
+  @Test
+  @Disabled
+  void deleteBranchSizeFail() {
+  }
+
+  @Test
+  @Disabled
+  void deleteBranchSizeSucceed() {
+  }
+
+  @Test
+  @Disabled
   void deleteWithConditionKeyFragment() {
   }
 

--- a/versioned/tiered/rocksdb/src/main/java/com/dremio/nessie/versioned/store/rocksdb/RocksDBStore.java
+++ b/versioned/tiered/rocksdb/src/main/java/com/dremio/nessie/versioned/store/rocksdb/RocksDBStore.java
@@ -235,12 +235,13 @@ public class RocksDBStore implements Store {
           // TODO: Critical Section - evaluating the condition expression and deleting the entity.
           // Check if condition expression is valid.
           RocksSerDe.deserializeToConsumer(type, value, consumer);
-          if (!(((Evaluator) consumer).evaluate(condition.get().accept(ROCKS_DB_CONDITION_EXPRESSION_VISITOR)))) {
-            throw new ConditionFailedException("Condition failed during delete operation.");
+          if (!(consumer.evaluate(condition.get().accept(ROCKS_DB_CONDITION_EXPRESSION_VISITOR)))) {
+            LOGGER.debug("Condition failed during delete operation.");
+            return false;
           }
         }
 
-        transaction.delete(columnFamilyHandle, value);
+        transaction.delete(columnFamilyHandle, id.toBytes());
         transaction.commit();
         return true;
       }

--- a/versioned/tiered/rocksdb/src/main/java/com/dremio/nessie/versioned/store/rocksdb/RocksDBStore.java
+++ b/versioned/tiered/rocksdb/src/main/java/com/dremio/nessie/versioned/store/rocksdb/RocksDBStore.java
@@ -228,25 +228,26 @@ public class RocksDBStore implements Store {
 
     try (final Transaction transaction = transactionDB.beginTransaction(new WriteOptions(), new OptimisticTransactionOptions())) {
       final byte[] value = transaction.getForUpdate(new ReadOptions(), columnFamilyHandle, id.toBytes(), true);
-      if (value != null) {
-        if (condition.isPresent()) {
-          final RocksBaseValue<C> consumer = RocksSerDe.getConsumer(type);
-          // TODO: Does the critical section need to be locked?
-          // TODO: Critical Section - evaluating the condition expression and deleting the entity.
-          // Check if condition expression is valid.
-          RocksSerDe.deserializeToConsumer(type, value, consumer);
-          if (!(consumer.evaluate(condition.get().accept(ROCKS_DB_CONDITION_EXPRESSION_VISITOR)))) {
-            LOGGER.debug("Condition failed during delete operation.");
-            return false;
-          }
-        }
 
-        transaction.delete(columnFamilyHandle, id.toBytes());
-        transaction.commit();
-        return true;
+      if (null == value) {
+        throw new NotFoundException("No value was found for the given id to delete.");
       }
 
-      throw new NotFoundException("No value was found for the given id to delete.");
+      if (condition.isPresent()) {
+        final RocksBaseValue<C> consumer = RocksSerDe.getConsumer(type);
+        // TODO: Does the critical section need to be locked?
+        // TODO: Critical Section - evaluating the condition expression and deleting the entity.
+        // Check if condition expression is valid.
+        RocksSerDe.deserializeToConsumer(type, value, consumer);
+        if (!(consumer.evaluate(condition.get().accept(ROCKS_DB_CONDITION_EXPRESSION_VISITOR)))) {
+          LOGGER.debug("Condition failed during delete operation.");
+          return false;
+        }
+      }
+
+      transaction.delete(columnFamilyHandle, id.toBytes());
+      transaction.commit();
+      return true;
     } catch (RocksDBException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Address code review comments:
- Added more delete() tests.
- Modified RocksDBStore - delete() to return false instead of throwing ConditionFailedException, to match the base Store API's Javadoc.
- Modified RocksDBStore - delete() to delete with the id.